### PR TITLE
Updating collector search expression to be valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,17 @@ Calling spaceship operator (<| |>) without tag can be dangerous because it will 
 #### What you have done
 
 ```puppet
-Package <| |>
+class foo {
+  Package <| |>
+}
 ```
 
 #### What you should have done
 
 ```puppet
-Package <| virtual == true |>
+class foo {
+  Package <| tag == 'foo' |>
+}
 ```
 
 #### Disabling the check


### PR DESCRIPTION
virtual == true was never accepted into puppet as a valid search expression.
Updating the expression to use a simple tag search instead.